### PR TITLE
Fix/OpenCV glLoadMatrixf undefined symbol 에러 해결

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,8 @@ RUN mkdir -p /usr/lib/x86_64-linux-gnu && \
         '/* OpenGL functions */' \
         'void glMatrixMode(unsigned int mode) {}' \
         'void glLoadIdentity(void) {}' \
+        'void glLoadMatrixf(const float* m) {}' \
+        'void glLoadMatrixd(const double* m) {}' \
         'void glPushMatrix(void) {}' \
         'void glPopMatrix(void) {}' \
         'void glOrtho(double left, double right, double bottom, double top, double near, double far) {}' \


### PR DESCRIPTION
## #️⃣ 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요. (이미지 첨부 가능)

## 🔧 작업 내용

OpenCV가 YOLO 모델 로드를 시도할 때 발생하던 `undefined symbol: glLoadMatrixf` 에러를 해결하기 위해 Dockerfile의 dummy OpenGL 라이브러리에 필요한 함수를 추가했습니다.

### 변경사항
- `glLoadMatrixf(const float* m)` 함수 추가
- `glLoadMatrixd(const double* m)` 함수 추가 (예방 차원)

## 🐛 해결하고자 한 문제

### 에러 메시지

현재 어디까지 진행?
-> 이미지 gps 추출까지는 성공.

## #️⃣ 테스트 결과

> 코드 변경에 대해 테스트를 수행한 결과를 요약해주세요. 예: 모든 테스트 통과 여부, 새로 작성한 테스트 케이스 등

## #️⃣ 스크린샷 (Swagger 등)

> 관련된 스크린샷이 있다면 여기에 첨부해주세요.

## 📎 참고 자료

> 관련 문서, 스크린샷, 또는 예시 등이 있다면 여기에 첨부해주세요

## ✅ 테스트 완료 여부

- [ ] Swagger
- [ ] 기타
